### PR TITLE
Don't expose non GPU devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 DOCKER_REPO ?= "nvcr.io/nvidia/kubevirt-gpu-device-plugin"
-DOCKER_TAG ?= v1.3.1-custom3
+DOCKER_TAG ?= v1.3.1-custom4
 
 PCI_IDS_URL ?= https://pci-ids.ucw.cz/v2.2/pci.ids
 

--- a/pkg/device_plugin/device_plugin.go
+++ b/pkg/device_plugin/device_plugin.go
@@ -43,6 +43,8 @@ import (
 
 const (
 	nvidiaVendorID = "10de"
+	pciVGAControllerClass    = "030000"
+	pci3DControllerClass     = "030200"
 )
 
 // Structure to hold details about Nvidia GPU Device
@@ -182,6 +184,16 @@ func createIommuDeviceMap() {
 		//Nvidia vendor id is "10de". Proceed if vendor id is 10de
 		if vendorID == "10de" {
 			log.Println("Nvidia device ", info.Name())
+			// Check if device is a GPU device
+			deviceClass, err := readIDFromFile(basePath, info.Name(), "class")
+			if err != nil {
+				log.Println("Could not get class ID for device ", info.Name())
+				return nil
+			}
+			if deviceClass != pciVGAControllerClass && deviceClass != pci3DControllerClass {
+				log.Println("Not a GPU device, skipping")
+				return nil
+			}
 			//Retrieve iommu group for the device
 			driver, err := readLink(basePath, info.Name(), "driver")
 			if err != nil {

--- a/pkg/device_plugin/device_plugin_test.go
+++ b/pkg/device_plugin/device_plugin_test.go
@@ -48,6 +48,7 @@ var deviceName = "1b80"
 var deviceName1 = "1b81"
 var vgpuDeviceName = "vGPUId"
 var vgpuDeviceName1 = "vGPUId1"
+var deviceClass = "030000"
 
 func getFakeLinkDevicePlugin(basePath string, deviceAddress string, link string) (string, error) {
 	if deviceAddress == deviceAddress1 {
@@ -82,16 +83,22 @@ func getFakeIDFromFileDevicePlugin(basePath string, deviceAddress string, link s
 			return nvVendorID, nil
 		} else if link == "device" {
 			return deviceName, nil
+		} else if link == "class" {
+			return deviceClass, nil
 		}
 	} else if deviceAddress == deviceAddress2 {
 		if link == "vendor" {
 			return nvVendorID, nil
 		} else if link == "device" {
 			return deviceName1, nil
+		} else if link == "class" {
+			return deviceClass, nil
 		}
 	} else if deviceAddress == deviceAddress3 {
 		if link == "vendor" {
 			return nvVendorID, nil
+		} else if link == "class" {
+			return deviceClass, nil
 		}
 	}
 	return "", errors.New("Incorrect operation")


### PR DESCRIPTION
This PR is patching the device plugin to avoid exposing non GPU devices (sound cards). To check if a PCI device is a GPU, we check that the PCI class associated to this device is `0x300000` or `0x302000`. Those PCI classes are associated to VGA or 3D controller devices.

This is required for multi GPUs support:
- Without this fix, when requesting 2 GPUs, the device plugin will generate a specifications with 4 PCI devices (2 GPUs and 2 sound cards) looking like `DEVICES=GPU1,SOUND_CARD1,GPU2,SOUND_CARD2`
- When Kubevirt is generating the VM spec, it will get the first 2 PCI devices specified by the device plugin, so in this case `GPU1` and `SOUND_CARD1`. The resulting VM will only have access to 1 GPU while we requested 2
- With this fix, the device plugin is ignoring the devices that are not video cards, and is generating a spec like `DEVICES=GPU1,GP2`, which is solving the issue