### PR TITLE
Add GB300 alias

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,3 +37,5 @@ GPUAliases:
     alias: L40S
   - GPUName: GA102GL_A40
     alias: A40
+  - GPUName: GB110_GB300
+    alias: GB300

--- a/utils/pci.ids
+++ b/utils/pci.ids
@@ -13496,6 +13496,7 @@
 	2f38  GB205GLM [RTX PRO 3000 Blackwell Generation Laptop GPU]
 	2f58  GB205M [GeForce RTX 5070 Ti Mobile]
 	31c0  GB110
+	31c2  GB110 [GB300]
 	3340  GB120
 10df  Emulex Corporation
 	0720  OneConnect NIC (Skyhawk)

--- a/versions.mk
+++ b/versions.mk
@@ -16,7 +16,7 @@ MODULE := kubevirt-gpu-device-plugin
 
 REGISTRY ?= nvcr.io/nvidia
 
-VERSION ?= v1.5.0-custom1
+VERSION ?= v1.5.0-custom2
 
 GOLANG_VERSION ?= 1.26.1
 


### PR DESCRIPTION
## Summary

GB300 (PCI device `10de:31c2`) is not in the `pci.ids` database yet, so `getDeviceName()` returns empty and the plugin falls back to the raw device id `"31c2"` as the resource name — GB300 GPUs get advertised as `nvidia.com/31c2` instead of `nvidia.com/GB300`.

Add a `GPUAliases` entry mapping `"31c2" → GB300`. This matches the plugin's raw-id fallback and survives `pci.ids` re-downloads (editing `utils/pci.ids` would be overwritten by `make update-pcidb`, and the image copies the checked-in copy).

Also bumps `VERSION` to `v1.5.0-custom2`.

## Verified
- `go build ./...` and `go test ./pkg/device_plugin/...` pass.
- Config parses: `31c2 → GB300`.