### PR TITLE
Add GB10 (DGX Spark) alias

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,3 +39,5 @@ GPUAliases:
     alias: A40
   - GPUName: GB110_GB300
     alias: GB300
+  - GPUName: GB20B_GB10
+    alias: GB10

--- a/utils/pci.ids
+++ b/utils/pci.ids
@@ -13490,6 +13490,7 @@
 	2db8  GB207GLM [RTX PRO 1000 Blackwell Generation Laptop GPU]
 	2db9  GB207GLM [RTX PRO 500 Blackwell Generation Laptop GPU]
 	2dd8  GB207M [GeForce RTX 5050 Max-Q / Mobile]
+	2e12  GB20B [GB10]
 	2e2a  GB20B
 	2f04  GB205 [GeForce RTX 5070]
 	2f18  GB205M [GeForce RTX 5070 Ti Mobile]

--- a/versions.mk
+++ b/versions.mk
@@ -16,7 +16,7 @@ MODULE := kubevirt-gpu-device-plugin
 
 REGISTRY ?= nvcr.io/nvidia
 
-VERSION ?= v1.5.0-custom2
+VERSION ?= v1.5.0-custom3
 
 GOLANG_VERSION ?= 1.26.1
 


### PR DESCRIPTION
## Summary

GB10 / DGX Spark (PCI device `10de:2e12`) is not in the checked-in `pci.ids` snapshot, so `getDeviceName()` returns empty and the plugin falls back to the raw device id `"2e12"` — DGX Spark GPUs get advertised as `nvidia.com/2e12` instead of `nvidia.com/GB10`.

Mirrors the GB300 change (#5):

- **`utils/pci.ids`**: add `2e12  GB20B [GB10]` (matches the upstream pciids naming: chip `GB20B`, product `GB10`). Editing the checked-in copy (rather than relying on `make update-pcidb`) survives re-downloads, same as the GB300 entry.
- **`config.yaml`**: add `GPUAliases` `GB20B_GB10 → GB10`. `getDeviceName()` uppercases + replaces whitespace with `_` + strips non-alphanumeric, so `"GB20B [GB10]"` normalizes to `"GB20B_GB10"`.
- **`versions.mk`**: bump `VERSION` to `v1.5.0-custom3`.

## Verified

- `go build ./...` and `go test ./pkg/device_plugin/...` pass.
- Config parses; the normalized device name `GB20B_GB10` matches the alias `GPUName`, so `2e12 → GB10` end to end.

## Related
- Follows #5 (GB300 alias). Pairs with workload-clusters DGX Spark MR (adds the `p4242-0106` node) and the forthcoming arc-nvks-argocd `gb10` runner entry.
- After merge + `v1.5.0-custom3` image build, bump `SANDBOX_DEVICE_PLUGIN_VERSION` in arc-nvks-argocd so nodes advertise `nvidia.com/GB10`.